### PR TITLE
Extracted paths in notebooks into separate json file

### DIFF
--- a/Metadata.ipynb
+++ b/Metadata.ipynb
@@ -14,6 +14,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import json\n",
     "import pandas as pd\n",
     "from unipark import Preprocessor, CodeBookParser\n",
     "from unipark import MetadataManipulator as MdManipulator\n",
@@ -27,9 +28,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_csv = './test/data.csv'\n",
-    "codebook_path = './test/codebook.csv'\n",
-    "figures_save_dir = './test/figs/md'"
+    "# load the paths to the input CSV, codebook, and figures save directory from the paths.json file located in the same directory\n",
+    "with open('paths.json') as f:\n",
+    "    paths = json.load(f)\n",
+    "input_csv = paths['input_csv']\n",
+    "codebook_path = paths['codebook_path']\n",
+    "figures_save_dir = paths['figures_save_dir_metadata']"
    ]
   },
   {

--- a/Report_auto_gen.ipynb
+++ b/Report_auto_gen.ipynb
@@ -28,9 +28,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "codebook_path = './test/codebook.csv'\n",
-    "input_csv = './test/data.csv'\n",
-    "figures_save_dir = './test/figs/auto_gen'"
+    "# load the paths to the input CSV, codebook, and figures save directory from the paths.json file located in the same directory\n",
+    "with open('paths.json') as f:\n",
+    "    paths = json.load(f)\n",
+    "input_csv = paths['input_csv']\n",
+    "codebook_path = paths['codebook_path']\n",
+    "figures_save_dir = paths['figures_save_dir_autogen']"
    ]
   },
   {

--- a/paths.json
+++ b/paths.json
@@ -1,0 +1,6 @@
+{
+  "input_csv": "./test/data.csv",
+  "codebook_path": "./test/codebook.csv",
+  "figures_save_dir_metadata": "./test/figs/md",
+  "figures_save_dir_autogen": "./test/figs/auto_gen"
+}


### PR DESCRIPTION
Removing the paths from the notebook and offloading them into a separate config file `paths.json`.